### PR TITLE
[FIX] Added tests for product delete endpoint and service

### DIFF
--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -81,6 +81,30 @@ class TestCreateProduct(object):
         assert response.json()['error'] == 'VALIDATION_ERROR'
 
 
+class TestDeleteProduct(object):
+    def test_can_delete_product(self, gateway_service, web_session):
+        gateway_service.products_rpc.get.return_value = {
+            "in_stock": 10,
+            "maximum_speed": 5,
+            "id": "the_odyssey",
+            "passenger_capacity": 101,
+            "title": "The Odyssey"
+        }
+        response = web_session.delete('/products/the_odyssey')
+        assert response.status_code == 200
+        assert response.json() == {}
+
+    def test_delete_product_not_found(self, gateway_service, web_session):
+        gateway_service.products_rpc.delete.side_effect = (
+            ProductNotFound('missing'))
+
+        response = web_session.delete('/products/the_odyssey')
+        assert response.status_code == 404
+        payload = response.json()
+        assert payload["error"] == "PRODUCT_NOT_FOUND"
+        assert payload["message"] == "missing"
+
+
 class TestGetOrder(object):
 
     def test_can_get_order(self, gateway_service, web_session):


### PR DESCRIPTION
- Updated
    - [X] `gateway/test/interface/test_service.py`
    - [X] `products/test/test_service.py`